### PR TITLE
Removed deprecated function and Updated tested upto versions.

### DIFF
--- a/admin/page/dashboard.php
+++ b/admin/page/dashboard.php
@@ -12,8 +12,6 @@ $author_cap = rtbiz_get_access_role_cap( RTBIZ_TEXT_DOMAIN, 'author' );
 ?>
 <div class="wrap">
 
-	<?php screen_icon(); ?>
-
 	<h2><?php echo $menu_label . ' ' . __( 'Dashboard' ); ?></h2>
 
 	<?php

--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,8 @@ rtBiz - WordPress 4 Business!
 **Contributors:** [rtcamp](https://profiles.wordpress.org/rtcamp), [rahul286](https://profiles.wordpress.org/rahul286), [dipesh.kakadiya](https://profiles.wordpress.org/dipesh.kakadiya), [utkarshpatel](https://profiles.wordpress.org/utkarshpatel), [desaiuditd](https://profiles.wordpress.org/desaiuditd), [faishal](https://profiles.wordpress.org/faishal), [pareshradadiya](https://profiles.wordpress.org/pareshradadiya)  
 **Tags:** [contacts](https://wordpress.org/plugins/tags/contacts), [companies](https://wordpress.org/plugins/tags/companies), [people management](https://wordpress.org/plugins/tags/people management), [business](https://wordpress.org/plugins/tags/business), [email parsing](https://wordpress.org/plugins/tags/email+parsing), [attributes](https://wordpress.org/plugins/tags/attributes), [user groups](https://wordpress.org/plugins/tags/user+groups), [access control](https://wordpress.org/plugins/tags/access+control), [acl](https://wordpress.org/plugins/tags/acl), [wordpress](https://wordpress.org/plugins/tags/wordpress)  
 **Requires at least:** 4.1  
-**Tested up to:** 4.5.1  
-**Stable tag:** 1.4.2  
+**Tested up to:** 5.4  
+**Stable tag:** 1.4.3 
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 **Donate Link:** http://rtcamp.com/donate  
 
@@ -89,6 +89,10 @@ Please refer to the documentation.
 ![Departments](assets/screenshot-7.png)
 
 ## Changelog ##
+
+### 1.4.3 ###
+* Fixed - Removed deprecated function screen_icon.
+* Tested with 5.4
 
 ### 1.4.2 ###
 * Fixed - JS issue with WordPress 4.5

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors:      rtcamp, rahul286, dipesh.kakadiya, utkarshpatel, desaiuditd, 
 Donate Link:       http://rtcamp.com/donate
 Tags:              contacts, companies, people management, business, email parsing, attributes, user groups, access control, acl, wordpress
 Requires at least: 4.1
-Tested up to:      4.5.1
-Stable tag:        1.4.2
+Tested up to:      5.4
+Stable tag:        1.4.3
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -67,6 +67,10 @@ Please refer to the documentation.
 7. Departments
 
 == Changelog ==
+
+= 1.4.3 =
+* Fixed - Removed deprecated function screen_icon.
+* Tested with 5.4
 
 = 1.4.2 =
 * Fixed - JS issue with WordPress 4.5

--- a/rtbiz.php
+++ b/rtbiz.php
@@ -16,7 +16,7 @@
  * Plugin Name:       rtBiz
  * Plugin URI:        https://rtcamp.com/
  * Description:       WordPress for Business
- * Version:           1.4.2
+ * Version:           1.4.3
  * Author:            rtCamp
  * Author URI:        https://rtcamp.com/
  * License:           GPL-2.0+
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'RTBIZ_VERSION' ) ) {
-	define( 'RTBIZ_VERSION', '1.4.2' );
+	define( 'RTBIZ_VERSION', '1.4.3' );
 }
 
 if ( ! defined( 'RTBIZ_TEXT_DOMAIN' ) ) {


### PR DESCRIPTION
1)  Removed `screen_icon` function deprecated from WP 3.8 and has no functional value.
2) Updated plugin version and tested up to versions.