### PR TITLE
Maintenance: Grunt Build

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,4 +1,6 @@
 'use strict';
+const sass = require('node-sass');
+
 module.exports = function ( grunt ) {
 
 	// load all grunt tasks matching the `grunt-*` pattern
@@ -21,6 +23,7 @@ module.exports = function ( grunt ) {
 		sass: {
 			dist: {
 				options: {
+					implementation: sass,
 					style: 'expanded'
 				},
 				files: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
 	"name": "Helpdesk",
 	"dependencies": {
-		"load-grunt-tasks": "~0.2.1"
+		"grunt-sass": "^3.1.0",
+		"load-grunt-tasks": "~0.2.1",
+		"node-sass": "^7.0.1"
 	},
 	"devDependencies": {
 		"grunt": "^0.4.5",
@@ -9,7 +11,6 @@
 		"grunt-browser-sync": "^2.1.3",
 		"grunt-contrib-cssmin": "^0.12.3",
 		"grunt-contrib-jshint": "^0.11.2",
-		"grunt-contrib-sass": "^0.9.2",
 		"grunt-contrib-uglify": "^0.9.1",
 		"grunt-contrib-watch": "^0.6.1",
 		"load-grunt-tasks": "^3.2.0"


### PR DESCRIPTION
The current grunt build requires `node-sass` to be installed globally in the system path. This is not an issue itself. But enabling grunt build to have local build dependencies will be more useful for a distributed dev team. This PR addresses it.