### PR TITLE
sync: ensure old profile permissions are always an array

### DIFF
--- a/admin/classes/metabox/rtbiz-contact-profile-access/class-rtbiz-contact-profile-access.php
+++ b/admin/classes/metabox/rtbiz-contact-profile-access/class-rtbiz-contact-profile-access.php
@@ -81,6 +81,11 @@ if ( ! class_exists( 'Rtbiz_Contact_Profile_Access' ) ) {
 					$profile_permissions     = $_REQUEST['rtbiz_profile_permissions'];
 					$old_profile_permissions = get_post_meta( $contact_id, 'rtbiz_profile_permissions', true );
 
+					// Ensure $old_profile_permissions is always an array
+					if ( ! is_array( $old_profile_permissions ) ) {
+						$old_profile_permissions = array();
+					}
+
 					//if helpdesk exist rtbiz & helpdesk permission are same and rtbiz acl is hidden
 					if ( is_plugin_active( 'rtbiz-helpdesk/rtbiz-helpdesk.php' ) ) {
 						$profile_permissions[ RTBIZ_TEXT_DOMAIN ]                   = $profile_permissions[ RTBIZ_HD_TEXT_DOMAIN ];


### PR DESCRIPTION
This commit syncs the change: https://github.com/rtCamp/rtmedia-io/commit/cd4d33f3c980eb93caeb55dc2c0397086309b185 from rtbiz plugin inside [rtmedia-io](https://github.com/rtCamp/rtmedia-io) repo to the original rtbiz plugin

Closes - #115 