### PR TITLE
sync: Add build commands section to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,10 @@ rtBiz - WordPress 4 Business!
 
 Same [GPL] (http://www.gnu.org/licenses/gpl-2.0.txt) that WordPress uses!
 
+**Build Commands**
+- npx grunt
+- npx grunt build
+
 **Coming soon:**
 
  * Export Library


### PR DESCRIPTION
This commit syncs the change: https://github.com/rtCamp/rtmedia-io/commit/7aaefe72cd18d6d3df45c5c282675f382d00841a from rtbiz plugin inside [rtmedia-io](https://github.com/rtCamp/rtmedia-io) repo to the original rtbiz plugin

Closes - #115 